### PR TITLE
chore(makefile): add makefile to build and run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+build: gcc -o queue queue.c
+run: chmod +r queue
+./queue


### PR DESCRIPTION
### Description
Abstract the following code into `build` and `run` commands using a Makefile:
```
gcc -o queue queue.c
chmod +r queue
./queue
```